### PR TITLE
Add PWA support for native app feel on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ See [isomux.com](https://isomux.com) for setup instructions and a live demo. Rea
 - [**Shared task board**](https://x.com/Nil053/status/2040871759529025617): humans and agents can create, assign, claim, and close tasks — full interop via UI and HTTP API
 - **Image/PDF attachments**: agents understand images and PDFs. Agents can show images inline in the conversation
 - **Sound notifications**: get pinged when an agent finishes
+- **Installable as a PWA**: add to your home screen for a native app feel (requires HTTPS)
 
 ## Get Started
 
@@ -116,6 +117,7 @@ For persistent server setup (systemd + Tailscale) and voice input configuration,
 - **Full conversation view** with readable font sizes and two-row header
 - **Send & abort buttons** for touch input
 - Safe area insets for notch/home bar devices
+- **Installable as a PWA** — add to home screen for a native app feel (HTTPS or localhost)
 
 ### Notifications
 - **Sound notification** when agent finishes and tab is unfocused

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "react-dom": "^19.0.0",
       },
       "devDependencies": {
+        "@resvg/resvg-js": "^2.6.2",
         "@types/bun": "latest",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -66,6 +67,32 @@
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@resvg/resvg-js": ["@resvg/resvg-js@2.6.2", "", { "optionalDependencies": { "@resvg/resvg-js-android-arm-eabi": "2.6.2", "@resvg/resvg-js-android-arm64": "2.6.2", "@resvg/resvg-js-darwin-arm64": "2.6.2", "@resvg/resvg-js-darwin-x64": "2.6.2", "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2", "@resvg/resvg-js-linux-arm64-gnu": "2.6.2", "@resvg/resvg-js-linux-arm64-musl": "2.6.2", "@resvg/resvg-js-linux-x64-gnu": "2.6.2", "@resvg/resvg-js-linux-x64-musl": "2.6.2", "@resvg/resvg-js-win32-arm64-msvc": "2.6.2", "@resvg/resvg-js-win32-ia32-msvc": "2.6.2", "@resvg/resvg-js-win32-x64-msvc": "2.6.2" } }, "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q=="],
+
+    "@resvg/resvg-js-android-arm-eabi": ["@resvg/resvg-js-android-arm-eabi@2.6.2", "", { "os": "android", "cpu": "arm" }, "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA=="],
+
+    "@resvg/resvg-js-android-arm64": ["@resvg/resvg-js-android-arm64@2.6.2", "", { "os": "android", "cpu": "arm64" }, "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ=="],
+
+    "@resvg/resvg-js-darwin-arm64": ["@resvg/resvg-js-darwin-arm64@2.6.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A=="],
+
+    "@resvg/resvg-js-darwin-x64": ["@resvg/resvg-js-darwin-x64@2.6.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw=="],
+
+    "@resvg/resvg-js-linux-arm-gnueabihf": ["@resvg/resvg-js-linux-arm-gnueabihf@2.6.2", "", { "os": "linux", "cpu": "arm" }, "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw=="],
+
+    "@resvg/resvg-js-linux-arm64-gnu": ["@resvg/resvg-js-linux-arm64-gnu@2.6.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg=="],
+
+    "@resvg/resvg-js-linux-arm64-musl": ["@resvg/resvg-js-linux-arm64-musl@2.6.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg=="],
+
+    "@resvg/resvg-js-linux-x64-gnu": ["@resvg/resvg-js-linux-x64-gnu@2.6.2", "", { "os": "linux", "cpu": "x64" }, "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw=="],
+
+    "@resvg/resvg-js-linux-x64-musl": ["@resvg/resvg-js-linux-x64-musl@2.6.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ=="],
+
+    "@resvg/resvg-js-win32-arm64-msvc": ["@resvg/resvg-js-win32-arm64-msvc@2.6.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ=="],
+
+    "@resvg/resvg-js-win32-ia32-msvc": ["@resvg/resvg-js-win32-ia32-msvc@2.6.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w=="],
+
+    "@resvg/resvg-js-win32-x64-msvc": ["@resvg/resvg-js-win32-x64-msvc@2.6.2", "", { "os": "win32", "cpu": "x64" }, "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@resvg/resvg-js": "^2.6.2",
     "@types/bun": "latest",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,3 +5,8 @@ set -euo pipefail
 bun build ui/index.tsx --outdir ui/dist --production
 cp ui/index.html ui/dist/index.html
 cp node_modules/@xterm/xterm/css/xterm.css ui/dist/xterm.css
+
+# PWA assets
+cp ui/sw.js ui/dist/sw.js
+cp ui/manifest.json ui/dist/manifest.json
+bun run scripts/generate-icons.ts

--- a/scripts/generate-icons.ts
+++ b/scripts/generate-icons.ts
@@ -1,0 +1,24 @@
+import { Resvg } from "@resvg/resvg-js";
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+
+const outDir = "ui/dist/icons";
+mkdirSync(outDir, { recursive: true });
+
+const sizes = [
+  { src: "ui/icon.svg", name: "icon", sizes: [180, 192, 512] },
+  { src: "ui/icon-maskable.svg", name: "icon", sizes: [512], suffix: "-maskable" },
+];
+
+for (const { src, name, sizes: dims, suffix } of sizes) {
+  const svg = readFileSync(src, "utf-8");
+  for (const size of dims) {
+    const resvg = new Resvg(svg, { fitTo: { mode: "width", value: size } });
+    const png = resvg.render().asPng();
+    const filename = `${name}-${size}${suffix ?? ""}.png`;
+    writeFileSync(`${outDir}/${filename}`, png);
+  }
+}
+
+// Copy SVG icon too
+const svgSource = readFileSync("ui/icon.svg");
+writeFileSync(`${outDir}/icon.svg`, svgSource);

--- a/site/index.html
+++ b/site/index.html
@@ -673,6 +673,7 @@
       <li><a href="https://x.com/Nil053/status/2040871759529025617" target="_blank" rel="noopener"><strong>Shared task board</strong></a>: humans and agents can create, assign, claim, and close tasks &mdash; full interop via UI and HTTP API</li>
       <li><strong>Image/PDF attachments</strong>: agents understand images and PDFs. Agents can show images inline in the conversation</li>
       <li><strong>Sound notifications</strong>: get pinged when an agent finishes</li>
+      <li><strong>Installable as a PWA</strong>: add to your home screen for a native app feel (requires HTTPS)</li>
     </ul>
 
     <p style="color: var(--text-dim); font-size: 0.95rem;">See the <a href="https://github.com/nmamano/isomux#full-feature-list" target="_blank" rel="noopener">full feature list</a> on GitHub.</p>
@@ -715,7 +716,7 @@ bun run dev</pre>
       <p>Isomux shines when you run it on your own always-on box/server (like a Mac Mini), and then access it from all your devices.</p>
       <p style="margin-top: 12px;">Your phone and laptop see the same conversations, in real time, with UIs optimized for each. Agents keep running even if you close the browser.</p>
       <p style="margin-top: 12px;">The best way to set this up quickly and securely is by taking advantage of <a href="https://tailscale.com/" target="_blank" rel="noopener"><strong>Tailscale</strong></a> (it's free): your server serves Isomux on <code style="background: var(--bg); padding: 1px 6px; border-radius: 4px; font-size: 0.85em;">localhost:4000</code>, and every other device reaches it at <code style="background: var(--bg); padding: 1px 6px; border-radius: 4px; font-size: 0.85em;">&lt;TAILSCALE_SERVER_IP&gt;:4000</code>.</p>
-      <p style="margin-top: 12px; color: var(--text-dim); font-size: 0.85rem;"><strong>Tip:</strong> On your phone, use &ldquo;Add to Home Screen&rdquo; for a full-screen app experience.</p>
+      <p style="margin-top: 12px; color: var(--text-dim); font-size: 0.85rem;"><strong>Tip:</strong> On your phone, use &ldquo;Add to Home Screen&rdquo; for a native app feel.</p>
 
       <h3>1. Install Tailscale</h3>
       <p>Install Tailscale on the server, your laptop, and your phone.</p>
@@ -740,12 +741,17 @@ lingering so it survives logout.</pre>
     </details>
   </section>
 
-  <!-- Voice Input -->
-  <section id="voice-input">
+  <!-- HTTPS Features -->
+  <section id="https-features">
     <details class="section-collapse">
-      <summary><h2 style="display: inline;">Voice Input <em style="font-weight: 400; font-size: 0.85em; color: var(--text-dim);">(optional)</em></h2></summary>
+      <summary><h2 style="display: inline;">HTTPS Features <em style="font-weight: 400; font-size: 0.85em; color: var(--text-dim);">(optional)</em></h2></summary>
     <div class="setup-card">
-      <p style="margin-bottom: 16px;">Isomux has built-in voice input to dictate prompts. This works out-of-the-box locally, but requires HTTPS for Tailscale. To enable voice input with Tailscale, follow these steps.</p>
+      <p style="margin-bottom: 16px;">Some features require a <strong>secure context</strong> (HTTPS or localhost). Over plain HTTP on a remote host, the app works normally but the following won't be available:</p>
+      <ul style="margin: 0 0 16px 20px; color: var(--text-dim);">
+        <li><strong>Voice input</strong> &mdash; browser microphone access requires HTTPS</li>
+        <li><strong>PWA install</strong> &mdash; "Add to Home Screen" requires a service worker, which requires HTTPS</li>
+      </ul>
+      <p style="margin-bottom: 16px;">These work out-of-the-box on <code style="background: var(--bg); padding: 1px 6px; border-radius: 4px; font-size: 0.85em;">localhost</code>. To enable them over Tailscale, follow these steps.</p>
       <h3>1. Enable HTTPS in Tailscale</h3>
       <p>Open the <a href="https://login.tailscale.com/admin/dns" target="_blank" rel="noopener">DNS page</a> of your Tailscale admin console. Enable <strong>MagicDNS</strong> if not already on, then enable <strong>HTTPS Certificates</strong>.</p>
 
@@ -755,7 +761,7 @@ lingering so it survives logout.</pre>
       <h3>3. Start the HTTPS proxy</h3>
       <p>Run this on the server (you can use the built-in terminal in Isomux):</p>
 <pre>tailscale serve --bg http://localhost:4000</pre>
-      <p style="margin-top: 8px; color: var(--text-dim); font-size: 0.85rem;">This tells Tailscale to proxy HTTPS traffic to your local Isomux server with a valid certificate. The <code style="background: var(--bg); padding: 1px 6px; border-radius: 4px; font-size: 0.85em;">--bg</code> flag makes it persist across reboots. Next time you visit <code style="background: var(--bg); padding: 1px 6px; border-radius: 4px; font-size: 0.85em;">http://my-mac-mini:4000</code>, Isomux will auto-redirect to HTTPS and the mic button will be active.</p>
+      <p style="margin-top: 8px; color: var(--text-dim); font-size: 0.85rem;">This tells Tailscale to proxy HTTPS traffic to your local Isomux server with a valid certificate. The <code style="background: var(--bg); padding: 1px 6px; border-radius: 4px; font-size: 0.85em;">--bg</code> flag makes it persist across reboots. Next time you visit <code style="background: var(--bg); padding: 1px 6px; border-radius: 4px; font-size: 0.85em;">http://my-mac-mini:4000</code>, Isomux will auto-redirect to HTTPS &mdash; voice input and PWA install will both be available.</p>
     </div>
     </details>
   </section>

--- a/ui/icon-maskable.svg
+++ b/ui/icon-maskable.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#181a20"/>
+  <svg x="10" y="10" width="80" height="80" viewBox="0 0 32 32">
+    <polygon points="16,2 30,10 16,18 2,10" fill="#40E880"/>
+    <polygon points="2,10 16,18 16,30 2,22" fill="#209050"/>
+    <polygon points="30,10 16,18 16,30 30,22" fill="#186840"/>
+    <polygon points="16,8 24,12.5 16,17 8,12.5" fill="#0d1117"/>
+    <text x="16" y="15" text-anchor="middle" font-size="6" font-family="monospace" font-weight="bold" fill="#40E880">&gt;_</text>
+  </svg>
+</svg>

--- a/ui/icon.svg
+++ b/ui/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'>
+  <polygon points='16,2 30,10 16,18 2,10' fill='#40E880'/>
+  <polygon points='2,10 16,18 16,30 2,22' fill='#209050'/>
+  <polygon points='30,10 16,18 16,30 30,22' fill='#186840'/>
+  <polygon points='16,8 24,12.5 16,17 8,12.5' fill='#0d1117'/>
+  <text x='16' y='15' text-anchor='middle' font-size='6' font-family='monospace' font-weight='bold' fill='#40E880'>&gt;_</text>
+</svg>

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,9 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+  <meta name="theme-color" content="#181a20" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <title>Isomux</title>
   <link rel="stylesheet" href="./xterm.css" />
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><polygon points='16,2 30,10 16,18 2,10' fill='%2340E880'/><polygon points='2,10 16,18 16,30 2,22' fill='%23209050'/><polygon points='30,10 16,18 16,30 30,22' fill='%23186840'/><polygon points='16,8 24,12.5 16,17 8,12.5' fill='%230d1117'/><text x='16' y='15' text-anchor='middle' font-size='6' font-family='monospace' font-weight='bold' fill='%2340E880'>%3E_</text></svg>" />
+  <link rel="icon" href="/icons/icon.svg" type="image/svg+xml" />
+  <link rel="apple-touch-icon" href="/icons/icon-180.png" />
+  <link rel="manifest" href="/manifest.json" />
 </head>
 <body>
   <div id="root"></div>

--- a/ui/index.tsx
+++ b/ui/index.tsx
@@ -13,3 +13,8 @@ root.render(
     </FeaturesProvider>
   </ThemeProvider>
 );
+
+// Register service worker for PWA installability
+if ("serviceWorker" in navigator && window.isSecureContext) {
+  navigator.serviceWorker.register("/sw.js");
+}

--- a/ui/manifest.json
+++ b/ui/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "Isomux",
+  "short_name": "Isomux",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "theme_color": "#181a20",
+  "background_color": "#181a20",
+  "icons": [
+    { "src": "/icons/icon.svg", "sizes": "any", "type": "image/svg+xml" },
+    { "src": "/icons/icon-180.png", "sizes": "180x180", "type": "image/png" },
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "/icons/icon-512-maskable.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}

--- a/ui/store.tsx
+++ b/ui/store.tsx
@@ -334,6 +334,11 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     document.documentElement.setAttribute("data-theme", theme);
     localStorage.setItem("isomux-theme", theme);
+    // Update PWA title bar / status bar color to match theme
+    const meta = document.querySelector('meta[name="theme-color"]');
+    if (meta) {
+      meta.setAttribute("content", theme === "dark" ? "#181a20" : "#f5f5f5");
+    }
   }, [theme]);
 
   const toggleTheme = useCallback(() => {

--- a/ui/sw.js
+++ b/ui/sw.js
@@ -1,0 +1,2 @@
+// No-op service worker to satisfy PWA installability requirement.
+// No caching. All requests pass through to the network.


### PR DESCRIPTION
Add web app manifest, no-op service worker, SVG/PNG icon generation, and theme-color meta tags so Isomux can be installed to the home screen. Update `README` and landing page to document the feature and consolidate the voice-input setup section into a broader HTTPS features section.

Fixes #5