### PR TITLE
Improve typography

### DIFF
--- a/ui/components/AgentListView.tsx
+++ b/ui/components/AgentListView.tsx
@@ -45,7 +45,6 @@ export function AgentListView({
         display: "flex",
         flexDirection: "column",
         overflow: "hidden",
-        fontFamily: "'DM Sans', sans-serif",
       }}
     >
       <MobileHeader

--- a/ui/components/ContextMenu.tsx
+++ b/ui/components/ContextMenu.tsx
@@ -152,7 +152,7 @@ function MenuItem({
         border: "none",
         background: "transparent",
         color: danger ? "var(--red)" : "var(--text-dim)",
-        fontFamily: small ? "'JetBrains Mono',monospace" : "'DM Sans',sans-serif",
+        fontFamily: small ? "'JetBrains Mono',monospace" : undefined,
         fontSize: small ? 11 : 13,
         borderRadius: 6,
         cursor: disabled ? "default" : "pointer",

--- a/ui/components/EditAgentDialog.tsx
+++ b/ui/components/EditAgentDialog.tsx
@@ -498,7 +498,6 @@ const cancelBtnStyle: React.CSSProperties = {
   color: "var(--text-dim)",
   fontSize: 12,
   cursor: "pointer",
-  fontFamily: "'DM Sans',sans-serif",
 };
 
 const chipStyle: React.CSSProperties = {
@@ -525,7 +524,6 @@ const saveBtnStyle: React.CSSProperties = {
   fontSize: 12,
   fontWeight: 600,
   cursor: "pointer",
-  fontFamily: "'DM Sans',sans-serif",
 };
 
 const randomBtnStyle: React.CSSProperties = {
@@ -536,5 +534,4 @@ const randomBtnStyle: React.CSSProperties = {
   color: "var(--text-dim)",
   fontSize: 12,
   cursor: "pointer",
-  fontFamily: "'DM Sans',sans-serif",
 };

--- a/ui/components/MobileHeader.tsx
+++ b/ui/components/MobileHeader.tsx
@@ -222,7 +222,6 @@ export function MobileHeader({
                     background: "transparent", border: "none",
                     color: "var(--text-primary)", fontSize: 14,
                     cursor: "pointer", textAlign: "left",
-                    fontFamily: "'DM Sans',sans-serif",
                   }}
                 >
                   <span style={{ width: 20, display: "flex", alignItems: "center", justifyContent: "center" }}>{item.icon}</span>

--- a/ui/components/OfficePromptModal.tsx
+++ b/ui/components/OfficePromptModal.tsx
@@ -195,7 +195,6 @@ const cancelBtnStyle: React.CSSProperties = {
   color: "var(--text-dim)",
   fontSize: 12,
   cursor: "pointer",
-  fontFamily: "'DM Sans',sans-serif",
 };
 
 const saveBtnStyle: React.CSSProperties = {
@@ -207,5 +206,4 @@ const saveBtnStyle: React.CSSProperties = {
   fontSize: 12,
   fontWeight: 600,
   cursor: "pointer",
-  fontFamily: "'DM Sans',sans-serif",
 };

--- a/ui/components/TaskView.tsx
+++ b/ui/components/TaskView.tsx
@@ -137,7 +137,6 @@ function TaskDetailPanel({ task, onClose, username, mode = "edit", agents = [], 
     background: "var(--bg-input)",
     color: "var(--text-primary)",
     fontSize: 13,
-    fontFamily: "'DM Sans',sans-serif",
     outline: "none",
     boxSizing: "border-box",
   };
@@ -260,7 +259,6 @@ function TaskDetailPanel({ task, onClose, username, mode = "edit", agents = [], 
               fontSize: 11,
               fontWeight: 600,
               cursor: "pointer",
-              fontFamily: "'DM Sans',sans-serif",
             }}
           >
             Discard
@@ -276,7 +274,6 @@ function TaskDetailPanel({ task, onClose, username, mode = "edit", agents = [], 
               fontSize: 11,
               fontWeight: 600,
               cursor: "pointer",
-              fontFamily: "'DM Sans',sans-serif",
             }}
           >
             Cancel
@@ -298,7 +295,6 @@ function TaskDetailPanel({ task, onClose, username, mode = "edit", agents = [], 
             fontSize: 12,
             fontWeight: 600,
             cursor: title.trim() ? "pointer" : "default",
-            fontFamily: "'DM Sans',sans-serif",
           }}
         >
           {mode === "create" ? "Create" : "Save"}
@@ -316,7 +312,6 @@ function TaskDetailPanel({ task, onClose, username, mode = "edit", agents = [], 
               fontSize: 12,
               fontWeight: 600,
               cursor: "pointer",
-              fontFamily: "'DM Sans',sans-serif",
             }}
           >
             {confirmDelete ? "Confirm?" : "Delete"}
@@ -477,7 +472,6 @@ export function TaskView({ username, onClose, onFocusAgent }: { username: string
     background: "var(--bg-input)",
     color: "var(--text-primary)",
     fontSize: 12,
-    fontFamily: "'DM Sans',sans-serif",
     outline: "none",
   };
 
@@ -489,7 +483,6 @@ export function TaskView({ username, onClose, onFocusAgent }: { username: string
         flexDirection: "column",
         background: "var(--bg-base)",
         color: "var(--text-primary)",
-        fontFamily: "'DM Sans',sans-serif",
       }}
     >
       {/* Header */}
@@ -518,7 +511,6 @@ export function TaskView({ username, onClose, onFocusAgent }: { username: string
               fontSize: 18,
               cursor: "pointer",
               padding: "2px 8px",
-              fontFamily: "'DM Sans',sans-serif",
             }}
           >
             &larr;
@@ -538,7 +530,6 @@ export function TaskView({ username, onClose, onFocusAgent }: { username: string
               fontSize: 11,
               fontWeight: 600,
               cursor: "pointer",
-              fontFamily: "'DM Sans',sans-serif",
             }}
           >
             Add
@@ -585,7 +576,6 @@ export function TaskView({ username, onClose, onFocusAgent }: { username: string
                 background: "var(--bg-input)",
                 color: "var(--text-primary)",
                 fontSize: 13,
-                fontFamily: "'DM Sans',sans-serif",
                 outline: "none",
               }}
             />

--- a/ui/components/UpdateModal.tsx
+++ b/ui/components/UpdateModal.tsx
@@ -3,7 +3,6 @@ import { useAppState } from "../store.tsx";
 import { CopyButton } from "./CopyButton.tsx";
 
 const REPO = "nmamano/isomux";
-const FONT = "'DM Sans', sans-serif";
 
 function shortSha(sha: string) {
   return sha.slice(0, 7);
@@ -40,7 +39,6 @@ const textStyle: React.CSSProperties = {
   fontSize: 13,
   color: "var(--text-dim)",
   lineHeight: 1.6,
-  fontFamily: FONT,
 };
 
 export function UpdateModal({ onClose }: { onClose: () => void }) {
@@ -87,11 +85,10 @@ export function UpdateModal({ onClose }: { onClose: () => void }) {
           maxWidth: isMobile ? "100%" : undefined,
           boxShadow: "0 20px 60px var(--shadow-heavy)",
           animation: "hudIn 0.2s ease-out",
-          fontFamily: FONT,
         }}
       >
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-          <h3 style={{ fontSize: 17, fontWeight: 700, margin: 0, color: "var(--text-primary)", fontFamily: FONT }}>
+          <h3 style={{ fontSize: 17, fontWeight: 700, margin: 0, color: "var(--text-primary)" }}>
             Update Available
           </h3>
           <CopyButton getText={getText} size={28} />
@@ -122,7 +119,7 @@ export function UpdateModal({ onClose }: { onClose: () => void }) {
           </li>
         </ol>
 
-        <p style={{ fontSize: 12, color: "var(--text-muted)", marginTop: 14, lineHeight: 1.5, fontStyle: "italic", fontFamily: FONT }}>
+        <p style={{ fontSize: 12, color: "var(--text-muted)", marginTop: 14, lineHeight: 1.5, fontStyle: "italic" }}>
           Tip: click the copy button to copy this notice to clipboard, then ask any agent to take care of it.
         </p>
 
@@ -138,7 +135,6 @@ export function UpdateModal({ onClose }: { onClose: () => void }) {
               fontSize: 12,
               fontWeight: 600,
               cursor: "pointer",
-              fontFamily: FONT,
             }}
           >
             Got it

--- a/ui/components/UsernameModal.tsx
+++ b/ui/components/UsernameModal.tsx
@@ -60,7 +60,6 @@ export function UsernameModal({
             fontWeight: 700,
             color: "var(--text-primary)",
             marginBottom: 16,
-            fontFamily: "'DM Sans',sans-serif",
           }}
         >
           What's your name? (Who's the boss?)
@@ -106,7 +105,6 @@ export function UsernameModal({
                 background: "var(--btn-surface)",
                 color: "var(--text-dim)",
                 fontSize: 13,
-                fontFamily: "'DM Sans',sans-serif",
                 cursor: "pointer",
               }}
             >
@@ -124,7 +122,6 @@ export function UsernameModal({
               color: canSubmit ? "var(--bg-base)" : "var(--text-ghost)",
               fontSize: 13,
               fontWeight: 600,
-              fontFamily: "'DM Sans',sans-serif",
               cursor: canSubmit ? "pointer" : "default",
               transition: "background 0.15s, color 0.15s",
             }}

--- a/ui/demo-entry.tsx
+++ b/ui/demo-entry.tsx
@@ -35,7 +35,6 @@ function DemoBanner() {
         padding: "6px 16px",
         background: "var(--bg-surface)",
         borderBottom: "1px solid var(--border-light)",
-        fontFamily: "'DM Sans',sans-serif",
         fontSize: 13,
         color: "var(--text-dim)",
       }}

--- a/ui/log-view/LogEntryCard.tsx
+++ b/ui/log-view/LogEntryCard.tsx
@@ -269,7 +269,7 @@ function UserMessage({ content, isMobile, username, attachments, agentId, canEdi
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
   return (
     <div style={{ margin: "12px 0", padding: "10px 14px", paddingRight: 40, borderRadius: 10, background: "var(--user-msg-bg)", borderLeft: "3px solid var(--accent)", position: "relative" }}>
-      <div style={{ fontSize: isMobile ? 12 : 10, fontWeight: 600, color: "var(--accent)", marginBottom: 4, fontFamily: "'DM Sans',sans-serif", textTransform: "uppercase", letterSpacing: "0.05em" }}>{(username ?? "You").toUpperCase()}</div>
+      <div style={{ fontSize: isMobile ? 12 : 10, fontWeight: 600, color: "var(--accent)", marginBottom: 4, textTransform: "uppercase", letterSpacing: "0.05em" }}>{(username ?? "You").toUpperCase()}</div>
       {content && <div style={{ color: "var(--text-secondary)", fontFamily: "'JetBrains Mono',monospace", fontSize: isMobile ? 15 : 13, lineHeight: 1.6, whiteSpace: "pre-wrap", overflowWrap: "break-word", wordBreak: "break-word" }}>{content}</div>}
       {attachments && attachments.length > 0 && agentId && (
         <AttachmentDisplay
@@ -410,7 +410,7 @@ function ThinkingBlock({ content, durationMs, isLastInTurn, turnEntries, isMobil
           display: "flex", alignItems: "center", gap: 6,
           padding: "4px 8px", border: "none", background: "transparent",
           color: "var(--text-faint)", fontSize: isMobile ? 13 : 11, cursor: "pointer",
-          fontFamily: "'DM Sans',sans-serif", width: "100%", textAlign: "left",
+          width: "100%", textAlign: "left",
         }}
       >
         <span style={{ transform: open ? "rotate(90deg)" : "rotate(0deg)", transition: "transform 0.15s", display: "inline-block" }}>&#9654;</span>
@@ -495,7 +495,6 @@ function ToolResult({ entry, isLastInTurn, turnEntries, isMobile }: { entry: Log
             marginTop: 4, padding: "2px 6px", border: "none",
             background: "var(--expand-btn)", borderRadius: 4,
             color: "var(--text-faint)", fontSize: isMobile ? 12 : 10, cursor: "pointer",
-            fontFamily: "'DM Sans',sans-serif",
           }}
         >
           {open ? "Show less" : "Show more"}
@@ -539,7 +538,7 @@ function SystemMessage({ content, isMobile }: { content: string; isMobile?: bool
       textAlign: isMultiline ? "left" : "center",
       color: isMultiline ? "var(--text-dim)" : "var(--text-ghost)",
       fontSize: isMultiline ? (isMobile ? 15 : 13) : (isMobile ? 13 : 11),
-      fontFamily: isMultiline ? "'JetBrains Mono',monospace" : "'DM Sans',sans-serif",
+      fontFamily: isMultiline ? "'JetBrains Mono',monospace" : undefined,
       fontStyle: isMultiline ? "normal" : "italic",
       ...(!isMultiline && { whiteSpace: "pre-wrap" }),
     }}>

--- a/ui/log-view/LogView.tsx
+++ b/ui/log-view/LogView.tsx
@@ -75,7 +75,6 @@ function ActivityIndicator({ state, stateChangedAt, agentId }: { state: AgentSta
         margin: "8px 0",
         color,
         fontSize: 12,
-        fontFamily: "'DM Sans',sans-serif",
         animation: "fadeIn 0.2s ease-out",
       }}
     >
@@ -99,7 +98,6 @@ function ActivityIndicator({ state, stateChangedAt, agentId }: { state: AgentSta
             background: "transparent",
             color,
             fontSize: 11,
-            fontFamily: "'DM Sans',sans-serif",
             cursor: "pointer",
             opacity: 0.8,
           }}
@@ -123,7 +121,7 @@ function HeaderTimer({ state, stateChangedAt }: { state: AgentState; stateChange
   return (
     <>
       <span style={{ color: "var(--text-ghost)" }}>&middot;</span>
-      <span style={{ color, fontSize: 12, fontFamily: "'DM Sans',sans-serif" }}>
+      <span style={{ color, fontSize: 12 }}>
         {STATE_LABELS[state]} {formatElapsed(elapsedMs)}
       </span>
     </>
@@ -654,7 +652,6 @@ export function LogView({
               border: "1px solid var(--border-medium)",
               background: "var(--btn-surface)",
               color: "var(--text-dim)",
-              fontFamily: "'DM Sans',sans-serif",
               fontSize: 13,
               cursor: "pointer",
             }}
@@ -757,7 +754,6 @@ export function LogView({
                   color: "var(--text-muted)",
                   fontSize: 12,
                   padding: "1px 6px",
-                  fontFamily: "'DM Sans',sans-serif",
                   outline: "none",
                   width: 200,
                 }}
@@ -797,7 +793,6 @@ export function LogView({
                   color: "var(--text-dim)",
                   fontSize: 11,
                   cursor: "pointer",
-                  fontFamily: "'DM Sans',sans-serif",
                 }}
               >
                 Tasks
@@ -855,7 +850,6 @@ export function LogView({
                 border: `1px solid ${terminalOpen ? "var(--green-border)" : "var(--border-medium)"}`,
                 background: terminalOpen ? "var(--green-bg)" : "var(--btn-surface)",
                 color: terminalOpen ? "var(--green)" : "var(--text-dim)",
-                fontFamily: "'DM Sans',sans-serif",
                 fontSize: 12,
                 cursor: "pointer",
                 transition: "all 0.15s",
@@ -915,7 +909,6 @@ export function LogView({
               color: "var(--text-ghost)",
               textAlign: "center",
               marginTop: 40,
-              fontFamily: "'DM Sans',sans-serif",
             }}
           >
             Send a message to start a conversation.
@@ -1104,7 +1097,6 @@ export function LogView({
                         <span style={{
                           fontSize: 10,
                           color: "var(--text-ghost)",
-                          fontFamily: "'DM Sans',sans-serif",
                           background: "var(--bg-base)",
                           padding: "1px 6px",
                           borderRadius: 4,
@@ -1117,7 +1109,6 @@ export function LogView({
                         <span style={{
                           fontSize: 11,
                           color: "var(--text-ghost)",
-                          fontFamily: "'DM Sans',sans-serif",
                           overflow: "hidden",
                           textOverflow: "ellipsis",
                           whiteSpace: "nowrap",
@@ -1279,7 +1270,6 @@ export function LogView({
                   borderRadius: 8,
                   padding: "12px 14px",
                   fontSize: 12,
-                  fontFamily: "'DM Sans',sans-serif",
                   color: "var(--text-secondary)",
                   boxShadow: "0 4px 16px rgba(0,0,0,0.4)",
                   zIndex: 20,

--- a/ui/log-view/TerminalPanel.tsx
+++ b/ui/log-view/TerminalPanel.tsx
@@ -188,7 +188,6 @@ export function TerminalPanel({
         <span
           style={{
             fontSize: 11,
-            fontFamily: "'DM Sans',sans-serif",
             color: "var(--text-dim)",
             display: "flex",
             alignItems: "center",
@@ -241,7 +240,6 @@ export function TerminalPanel({
             alignItems: "center",
             gap: 12,
             fontSize: 12,
-            fontFamily: "'DM Sans',sans-serif",
             color: "var(--text-dim)",
             boxShadow: "0 4px 12px var(--shadow)",
           }}
@@ -256,7 +254,6 @@ export function TerminalPanel({
               background: "var(--green-bg)",
               color: "var(--green)",
               fontSize: 12,
-              fontFamily: "'DM Sans',sans-serif",
               cursor: "pointer",
             }}
           >

--- a/ui/office/OfficeView.tsx
+++ b/ui/office/OfficeView.tsx
@@ -69,7 +69,6 @@ export function OfficeView({ onSpawn, onContextMenu, username, onEditUsername, o
         overflow: "hidden",
         background: "var(--bg-base)",
         color: "var(--text-primary)",
-        fontFamily: "'DM Sans',sans-serif",
       }}
     >
       {/* Top HUD bar */}
@@ -169,7 +168,6 @@ export function OfficeView({ onSpawn, onContextMenu, username, onEditUsername, o
                 color: "var(--text-dim)",
                 fontSize: 11,
                 cursor: "pointer",
-                fontFamily: "'DM Sans',sans-serif",
               }}
             >
               Tasks
@@ -184,7 +182,6 @@ export function OfficeView({ onSpawn, onContextMenu, username, onEditUsername, o
                 color: "var(--text-dim)",
                 fontSize: 11,
                 cursor: "pointer",
-                fontFamily: "'DM Sans',sans-serif",
               }}
             >
               Office settings

--- a/ui/styles.ts
+++ b/ui/styles.ts
@@ -228,11 +228,12 @@ export const CSS = `
     83% { opacity: 1; }
   }
 
-  body { background: var(--bg-base); overflow:hidden; }
+  body { background: var(--bg-base); overflow:hidden; font-family: 'DM Sans', sans-serif; }
   html, body { max-width: 100vw; overflow-x: hidden; }
+  input, select, textarea, button { font-family: inherit; }
 
   /* Markdown content styles */
-  .md-content { font-family: 'DM Sans', sans-serif; font-size: 13px; line-height: 1.7; color: var(--text-secondary); }
+  .md-content { font-size: 13px; line-height: 1.7; color: var(--text-secondary); }
   .md-content p { margin: 0 0 8px 0; }
   .md-content p:last-child { margin-bottom: 0; }
   .md-content strong { color: var(--text-primary); font-weight: 600; }


### PR DESCRIPTION
Some UI elements had no font-family set and were defaulting to Times New Roman. This PR fixes the problem at its root by setting the DM Sans `font-family` on `body`, allowing us to remove all redundant inline declarations and obviating the need to add additional inline declarations.