### PR TITLE
Add zoom and click-to-drag panning to office view

### DIFF
--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useAppState, useDispatch } from "./store.tsx";
-import { OfficeView } from "./office/OfficeView.tsx";
+import { OfficeView, type ViewportControls } from "./office/OfficeView.tsx";
 import { LogView } from "./log-view/LogView.tsx";
 import { AgentListView } from "./components/AgentListView.tsx";
 import { ContextMenu } from "./components/ContextMenu.tsx";
@@ -64,6 +64,7 @@ export function App() {
   // browser has no localStorage username yet.
   const needsInitialUser = usersLoaded && username === null;
 
+  const viewportControlsRef = useRef<ViewportControls | null>(null);
   const focusedAgent = focusedAgentId ? agents.find((a) => a.id === focusedAgentId) : null;
 
   const swipeRoomNext = useCallback(() => {
@@ -114,6 +115,22 @@ export function App() {
         setSpawnReady(null);
         setCtxMenu(null);
         setEditAgent(null);
+      }
+      // Viewport zoom/pan shortcuts (only from office view): 0 → reset, +/= → zoom in, - → zoom out.
+      // "=" accepted as an alias for "+" so users don't need Shift on US layouts.
+      // Ref is null when OfficeView isn't mounted (mobile list, log view, etc.) — don't swallow the key in those cases.
+      const vp = viewportControlsRef.current;
+      if (vp && !isInput && !focusedAgentId && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        if (e.key === "0") {
+          e.preventDefault();
+          vp.resetView();
+        } else if (e.key === "+" || e.key === "=") {
+          e.preventDefault();
+          vp.zoomIn();
+        } else if (e.key === "-") {
+          e.preventDefault();
+          vp.zoomOut();
+        }
       }
       // Number keys 1-8: focus agent at that desk in current room (only from office view)
       if (!isInput && !focusedAgentId && e.key >= "1" && e.key <= "8" && !e.metaKey && !e.ctrlKey && !e.altKey) {
@@ -242,6 +259,7 @@ export function App() {
           onOpenUpdate={() => setUpdateOpen(true)}
           onSwipeLeft={swipeRoomNext}
           onSwipeRight={swipeRoomPrev}
+          viewportControlsRef={viewportControlsRef}
         />
       )}
       {spawnPickerDesk !== null && (

--- a/ui/hooks/useSwipeLeftRight.ts
+++ b/ui/hooks/useSwipeLeftRight.ts
@@ -1,25 +1,51 @@
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useState, useCallback, RefCallback } from "react";
 
 const TRIGGER_THRESHOLD = 100;
 const MAX_VERTICAL = 80;
+
+function isActuallyHorizontallyScrollable(node: HTMLElement) {
+  const style = window.getComputedStyle(node);
+  const overflowX = style.overflowX;
+  const allowsScroll = overflowX === "auto" || overflowX === "scroll" || overflowX === "overlay";
+  return allowsScroll && node.scrollWidth > node.clientWidth;
+}
 
 export function useSwipeLeftRight(
   onSwipeLeft: () => void,
   onSwipeRight: () => void,
   enabled: boolean,
-) {
-  const ref = useRef<HTMLDivElement>(null);
+  /** Per-gesture predicate. If provided and returns false at touch-start, the swipe is not tracked
+   *  (used to cede one-finger drags to the viewport pan when the scene is zoomed in). */
+  shouldStart?: () => boolean,
+): RefCallback<HTMLDivElement> {
+  const [node, setNode] = useState<HTMLDivElement | null>(null);
   const startRef = useRef<{ x: number; y: number } | null>(null);
+  const multiTouchRef = useRef(false);
   const onSwipeLeftRef = useRef(onSwipeLeft);
   const onSwipeRightRef = useRef(onSwipeRight);
+  const shouldStartRef = useRef(shouldStart);
   onSwipeLeftRef.current = onSwipeLeft;
   onSwipeRightRef.current = onSwipeRight;
+  shouldStartRef.current = shouldStart;
+
+  const ref = useCallback<RefCallback<HTMLDivElement>>((nextNode) => {
+    setNode((prev) => (prev === nextNode ? prev : nextNode));
+  }, []);
 
   useEffect(() => {
-    if (!enabled || !ref.current) return;
-    const el = ref.current;
+    if (!enabled || !node) return;
+    const el = node;
 
     function onTouchStart(e: TouchEvent) {
+      multiTouchRef.current = e.touches.length > 1;
+      if (multiTouchRef.current) {
+        startRef.current = null;
+        return;
+      }
+      if (shouldStartRef.current && !shouldStartRef.current()) {
+        startRef.current = null;
+        return;
+      }
       const t = e.touches[0];
       let node = e.target as HTMLElement | null;
       while (node && node !== el) {
@@ -28,7 +54,7 @@ export function useSwipeLeftRight(
           startRef.current = null;
           return;
         }
-        if (node.scrollWidth > node.clientWidth) {
+        if (isActuallyHorizontallyScrollable(node)) {
           startRef.current = null;
           return;
         }
@@ -38,6 +64,12 @@ export function useSwipeLeftRight(
     }
 
     function onTouchMove(e: TouchEvent) {
+      // Cancel swipe if a second finger appears (pinch-to-zoom)
+      if (e.touches.length > 1) {
+        multiTouchRef.current = true;
+        startRef.current = null;
+        return;
+      }
       if (!startRef.current) return;
       const t = e.touches[0];
       const dy = Math.abs(t.clientY - startRef.current.y);
@@ -47,6 +79,12 @@ export function useSwipeLeftRight(
     }
 
     function onTouchEnd(e: TouchEvent) {
+      if (multiTouchRef.current) {
+        if (e.touches.length === 0) {
+          multiTouchRef.current = false;
+        }
+        return;
+      }
       if (!startRef.current) return;
       const t = e.changedTouches[0];
       const dx = t.clientX - startRef.current.x;
@@ -63,15 +101,26 @@ export function useSwipeLeftRight(
       }
     }
 
+    // iOS can cancel a touch sequence without a matching touchend (e.g. system
+    // gesture, notification, palm rejection). Reset unconditionally — even a
+    // partial cancel (one finger of a pinch) must clear the multi-touch guard
+    // so the remaining finger isn't silently dropped for the rest of its life.
+    function onTouchCancel() {
+      multiTouchRef.current = false;
+      startRef.current = null;
+    }
+
     el.addEventListener("touchstart", onTouchStart, { passive: true });
     el.addEventListener("touchmove", onTouchMove, { passive: true });
     el.addEventListener("touchend", onTouchEnd, { passive: true });
+    el.addEventListener("touchcancel", onTouchCancel, { passive: true });
     return () => {
       el.removeEventListener("touchstart", onTouchStart);
       el.removeEventListener("touchmove", onTouchMove);
       el.removeEventListener("touchend", onTouchEnd);
+      el.removeEventListener("touchcancel", onTouchCancel);
     };
-  }, [enabled]);
+  }, [enabled, node]);
 
   return ref;
 }

--- a/ui/log-view/LogView.tsx
+++ b/ui/log-view/LogView.tsx
@@ -469,7 +469,7 @@ export function LogView({
   const swipeRef = useSwipeLeftRight(onSwipeLeft ?? (() => {}), onSwipeRight ?? (() => {}), isMobile);
   const messagesRef: RefCallback<HTMLDivElement> = useCallback((node: HTMLDivElement | null) => {
     (scrollRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
-    (swipeRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
+    swipeRef(node);
   }, []);
 
   // Dismiss edit textarea when agent is no longer idle (e.g. another tab sent a message)

--- a/ui/office/DeskUnit.tsx
+++ b/ui/office/DeskUnit.tsx
@@ -97,6 +97,7 @@ export function DeskUnit({
     <div
       ref={containerRef}
       draggable
+      data-no-pan
       onDragStart={(e) => {
         e.dataTransfer.setData("text/plain", String(agent.desk));
         e.dataTransfer.effectAllowed = "move";

--- a/ui/office/EmptySlot.tsx
+++ b/ui/office/EmptySlot.tsx
@@ -38,6 +38,7 @@ export function EmptySlot({
       <svg width="180" height="160" viewBox="0 0 180 160" overflow="visible" style={{ pointerEvents: "none" }}>
         {/* Invisible hit area — only the diamond shape triggers hover/click */}
         <path
+          data-no-pan
           d="M40 126 L90 101 L140 126 L90 151 Z"
           fill="transparent"
           stroke="none"

--- a/ui/office/Floor.tsx
+++ b/ui/office/Floor.tsx
@@ -136,7 +136,7 @@ export function Walls({ onToggleTheme, onWallPanelClick, hasOfficePrompt, onOpen
           </circle>
         ))}
         {/* Moon — crescent via overlapping circles (clickable to toggle theme) */}
-        <g onClick={onToggleTheme} style={{ cursor: "pointer", pointerEvents: "auto" }}>
+        <g data-no-pan onClick={onToggleTheme} style={{ cursor: "pointer", pointerEvents: "auto" }}>
           <circle cx={-203} cy={-8} r={18} fill="transparent" />
           <circle cx={-203} cy={-8} r={12} fill="#E8E0C8" />
           <circle cx={-203 + moonPhase * 10} cy={-9} r={10} fill="#0a0e1a" />
@@ -149,7 +149,7 @@ export function Walls({ onToggleTheme, onWallPanelClick, hasOfficePrompt, onOpen
       <g clipPath="url(#window-clip)" className="window-day">
         <path d="M-285 115 L-145 45 L-145 -45 L-285 25 Z" fill="#87CEEB" />
         {/* Sun (clickable to toggle theme) */}
-        <g onClick={onToggleTheme} style={{ cursor: "pointer", pointerEvents: "auto" }}>
+        <g data-no-pan onClick={onToggleTheme} style={{ cursor: "pointer", pointerEvents: "auto" }}>
           <circle cx={-205} cy={-5} r={20} fill="transparent" />
           <circle cx={-205} cy={-5} r={14} fill="#F5D060" />
           <circle cx={-205} cy={-5} r={20} fill="#F5D060" opacity="0.15" />
@@ -167,7 +167,7 @@ export function Walls({ onToggleTheme, onWallPanelClick, hasOfficePrompt, onOpen
       <path d="M-285 70 L-145 0" stroke="var(--wall-decor)" strokeWidth="2" fill="none" />
 
       {/* Corkboard on left wall — casual, mutable feel */}
-      <g transform="translate(-55, -30) skewY(-27)" onClick={onOpenTasks} style={{ cursor: "pointer", pointerEvents: "auto" }}>
+      <g data-no-pan transform="translate(-55, -30) skewY(-27)" onClick={onOpenTasks} style={{ cursor: "pointer", pointerEvents: "auto" }}>
         {/* Board frame */}
         <rect x="-50" y="-40" width="95" height="70" rx="2" fill="#5a4430" stroke="#4a3620" strokeWidth="1" />
         {/* Cork surface */}
@@ -236,7 +236,7 @@ export function Walls({ onToggleTheme, onWallPanelClick, hasOfficePrompt, onOpen
       </g>
 
       {/* Framed wall sign on left wall — formal, authoritative feel */}
-      <g transform="translate(50, -75) skewY(-27)" onClick={(e) => onWallPanelClick?.(e.clientX, e.clientY)} style={{ cursor: "pointer", pointerEvents: "auto" }}>
+      <g data-no-pan transform="translate(50, -75) skewY(-27)" onClick={(e) => onWallPanelClick?.(e.clientX, e.clientY)} style={{ cursor: "pointer", pointerEvents: "auto" }}>
         {/* Outer frame — dark wood/brass */}
         <rect x="-30" y="-32" width="60" height="58" rx="2" fill="#3a3028" stroke="#2a2018" strokeWidth="1.2" />
         {/* Inner frame — thin brass inset */}
@@ -295,7 +295,7 @@ export function Walls({ onToggleTheme, onWallPanelClick, hasOfficePrompt, onOpen
       {/* On (dark mode) */}
       <g className="neon-sign-on" transform="translate(370, -5) skewY(27)" style={{ animation: "neonFlicker 5s ease-in-out infinite", filter: `drop-shadow(0 0 4px ${neon}) drop-shadow(0 0 12px ${neon})` }}>
         {/* Hit area */}
-        <rect x="-38" y="-18" width="92" height="32" fill="transparent" style={{ cursor: "pointer", pointerEvents: "auto" }} onClick={() => window.open("https://isomux.com", "_blank")} />
+        <rect data-no-pan x="-38" y="-18" width="92" height="32" fill="transparent" style={{ cursor: "pointer", pointerEvents: "auto" }} onClick={() => window.open("https://isomux.com", "_blank")} />
         {/* Letters as thick strokes */}
         <g fill="none" stroke={neon} strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
           {/* i — dot + stem */}
@@ -334,7 +334,7 @@ export function Walls({ onToggleTheme, onWallPanelClick, hasOfficePrompt, onOpen
       {/* Off (light mode) */}
       <g className="neon-sign-off" transform="translate(370, -5) skewY(27)">
         {/* Hit area */}
-        <rect x="-38" y="-18" width="92" height="32" fill="transparent" style={{ cursor: "pointer", pointerEvents: "auto" }} onClick={() => window.open("https://isomux.com", "_blank")} />
+        <rect data-no-pan x="-38" y="-18" width="92" height="32" fill="transparent" style={{ cursor: "pointer", pointerEvents: "auto" }} onClick={() => window.open("https://isomux.com", "_blank")} />
         <g fill="none" stroke="#444" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" opacity="0.7">
           <circle cx="-32" cy="-12" r="1.2" fill="#444" stroke="none" />
           <line x1="-32" y1="-8" x2="-32" y2="2" />
@@ -368,7 +368,7 @@ export function Walls({ onToggleTheme, onWallPanelClick, hasOfficePrompt, onOpen
 
       {/* Left wall door — leads to previous room */}
       {leftDoor && (
-        <g onClick={leftDoor.onClick} style={{ cursor: "pointer", pointerEvents: "auto" }}>
+        <g data-no-pan onClick={leftDoor.onClick} style={{ cursor: "pointer", pointerEvents: "auto" }}>
           <g transform="translate(-315, 237) skewY(-27)">
             <rect x="-33" y="-93" width="66" height="113" rx="3" fill={leftDoor.reject ? "#5a2020" : leftDoor.dragOver ? "#5a4a2a" : "#3a2a1a"} stroke="#2a1a0a" strokeWidth="1.5" />
             <rect x="-27" y="-87" width="54" height="101" rx="1.5" fill={leftDoor.reject ? "#7a3030" : leftDoor.dragOver ? "#7a6050" : "#5a4030"} />
@@ -388,7 +388,7 @@ export function Walls({ onToggleTheme, onWallPanelClick, hasOfficePrompt, onOpen
 
       {/* Right wall door — leads to next room */}
       {rightDoor && (
-        <g onClick={rightDoor.onClick} style={{ cursor: "pointer", pointerEvents: "auto" }}>
+        <g data-no-pan onClick={rightDoor.onClick} style={{ cursor: "pointer", pointerEvents: "auto" }}>
           <g transform="translate(555, 237) skewY(27)">
             <rect x="-33" y="-93" width="66" height="113" rx="3" fill={rightDoor.reject ? "#5a2020" : rightDoor.dragOver ? "#5a4a2a" : "#3a2a1a"} stroke="#2a1a0a" strokeWidth="1.5" />
             <rect x="-27" y="-87" width="54" height="101" rx="1.5" fill={rightDoor.reject ? "#7a3030" : rightDoor.dragOver ? "#7a6050" : "#5a4030"} />

--- a/ui/office/OfficeView.tsx
+++ b/ui/office/OfficeView.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useAppState, useDispatch, useTheme, useFeatures } from "../store.tsx";
 import { Floor, Walls } from "./Floor.tsx";
 import { RoomProps } from "./RoomProps.tsx";
@@ -14,6 +14,8 @@ import { NavActions, type NavAction } from "../components/NavActions.tsx";
 import { WallPanelMenu, type WallPanelMenuItem } from "../components/WallPanelMenu.tsx";
 import { TasksIcon, BuildingIcon, DoorIcon, ListIcon, DeviceIcon, ClockIcon, UserIcon } from "../components/NavIcons.tsx";
 import { useSwipeLeftRight } from "../hooks/useSwipeLeftRight.ts";
+import { useViewport } from "./useViewport.ts";
+import { ZoomControls } from "./ZoomControls.tsx";
 import type { AgentInfo } from "../../shared/types.ts";
 
 /** HTML drop zone positioned over an SVG door — SVG elements are unreliable drag-and-drop targets */
@@ -25,6 +27,7 @@ function DoorDropZone({ side, onDrop, onDragOverChange, onClick }: { side: "left
     : { position: "absolute", right: 0, top: 225, width: 85, height: 155, zIndex: 200 };
   return (
     <div
+      data-no-pan
       style={{ ...style, cursor: "pointer", background: reject ? "rgba(255,60,60,0.08)" : "transparent" }}
       onClick={onClick}
       onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = "move"; }}
@@ -43,7 +46,28 @@ function DoorDropZone({ side, onDrop, onDragOverChange, onClick }: { side: "left
   );
 }
 
-export function OfficeView({ onSpawn, onContextMenu, onOpenUserSettings, onOpenDeviceSettings, onEditOfficePrompt, onEditRoomSettings, onOpenTasks, onOpenCronjobs, onOpenUpdate, onSwipeLeft, onSwipeRight }: { onSpawn: (deskIndex: number) => void; onContextMenu: (x: number, y: number, agent: AgentInfo) => void; onOpenUserSettings: () => void; onOpenDeviceSettings: () => void; onEditOfficePrompt: () => void; onEditRoomSettings?: () => void; onOpenTasks: () => void; onOpenCronjobs: () => void; onOpenUpdate: () => void; onSwipeLeft?: () => void; onSwipeRight?: () => void }) {
+export interface ViewportControls {
+  resetView: () => void;
+  zoomIn: () => void;
+  zoomOut: () => void;
+}
+
+interface OfficeViewProps {
+  onSpawn: (deskIndex: number) => void;
+  onContextMenu: (x: number, y: number, agent: AgentInfo) => void;
+  onOpenUserSettings: () => void;
+  onOpenDeviceSettings: () => void;
+  onEditOfficePrompt: () => void;
+  onEditRoomSettings?: () => void;
+  onOpenTasks: () => void;
+  onOpenCronjobs: () => void;
+  onOpenUpdate: () => void;
+  onSwipeLeft?: () => void;
+  onSwipeRight?: () => void;
+  viewportControlsRef?: React.RefObject<ViewportControls | null>;
+}
+
+export function OfficeView({ onSpawn, onContextMenu, onOpenUserSettings, onOpenDeviceSettings, onEditOfficePrompt, onEditRoomSettings, onOpenTasks, onOpenCronjobs, onOpenUpdate, onSwipeLeft, onSwipeRight, viewportControlsRef }: OfficeViewProps) {
   const { agents, needsAttention, stateChangedAt, office, tasks, currentRoom, rooms, isMobile, updateAvailable } = useAppState();
   const roomCount = rooms.length;
   const roomNames = rooms.map((r) => r.name);
@@ -52,7 +76,39 @@ export function OfficeView({ onSpawn, onContextMenu, onOpenUserSettings, onOpenD
   const { theme, toggleTheme } = useTheme();
   const { embed } = useFeatures();
   const mobileScale = isMobile ? screen.width / (SCENE_W - 200) : 1;
-  const swipeRef = useSwipeLeftRight(onSwipeLeft ?? (() => {}), onSwipeRight ?? (() => {}), isMobile);
+  // layoutKey changes whenever the centered-scene static transform changes, so
+  // useViewport re-measures pan-clamp bounds (ResizeObserver alone won't catch
+  // transform-only updates).
+  const layoutKey = `${embed ? 1 : 0}|${isMobile ? 1 : 0}|${mobileScale}`;
+  const currentRoomId = rooms[currentRoom]?.id ?? "";
+  const roomIds = rooms.map((r) => r.id);
+  const viewport = useViewport(currentRoomId, roomIds, layoutKey, !embed);
+  // Cede one-finger swipes to pan once the user zooms in (iOS-gallery pattern).
+  const swipeRef = useSwipeLeftRight(
+    onSwipeLeft ?? (() => {}),
+    onSwipeRight ?? (() => {}),
+    isMobile,
+    () => !viewport.isZoomedIn(),
+  );
+  const attachContainer = useCallback((node: HTMLDivElement | null) => {
+    swipeRef(node);
+    viewport.setContainer(node);
+  }, [swipeRef, viewport.setContainer]);
+
+  // Expose viewport controls to parent for keyboard shortcuts (0, +, -). Skip
+  // in embed mode — the zoom UI is hidden there, and the keyboard parity
+  // should match.
+  useEffect(() => {
+    if (!viewportControlsRef || embed) {
+      return;
+    }
+    viewportControlsRef.current = {
+      resetView: viewport.resetView,
+      zoomIn: viewport.zoomIn,
+      zoomOut: viewport.zoomOut,
+    };
+    return () => { viewportControlsRef.current = null; };
+  }, [viewportControlsRef, embed, viewport.resetView, viewport.zoomIn, viewport.zoomOut]);
 
   // Filter agents to current room for rendering
   const roomAgents = agents.filter((a) => a.room === currentRoom);
@@ -186,7 +242,12 @@ export function OfficeView({ onSpawn, onContextMenu, onOpenUserSettings, onOpenD
       {!embed && <RoomTabBar />}
 
       {/* Office scene */}
-      <div ref={swipeRef} style={{ flex: 1, position: "relative", overflow: "hidden" }}>
+      {/* touch-action: none keeps iOS from turning one-finger drags into page scroll.
+          Room-swipe still works because that hook reads touch coordinates directly. */}
+      <div
+        ref={attachContainer}
+        style={{ flex: 1, position: "relative", overflow: "hidden", touchAction: "none" }}
+      >
         {/* Ambient gradients */}
         <div
           style={{
@@ -194,87 +255,102 @@ export function OfficeView({ onSpawn, onContextMenu, onOpenUserSettings, onOpenD
             inset: 0,
             background:
               "radial-gradient(ellipse at 50% 30%, var(--ambient-1) 0%, transparent 50%), radial-gradient(ellipse at 25% 65%, var(--ambient-2) 0%, transparent 35%), radial-gradient(ellipse at 75% 65%, var(--ambient-3) 0%, transparent 35%)",
+            pointerEvents: "none",
           }}
         />
 
-        {/* Single scene container — floor, walls, and desks share the same coordinate space */}
+        {/* Viewport layer — zoom/pan transform applies here, wrapping the centered scene */}
         <div
+          ref={viewport.setScene}
           style={{
             position: "absolute",
-            left: "50%",
-            top: embed ? (isMobile ? "55%" : "64%") : isMobile ? "45%" : "50%",
-            transform: embed
-              ? `translate(-50%, -50%) scale(${isMobile ? mobileScale * 0.85 : 0.9})`
-              : isMobile
-              ? `translate(-50%, -50%) scale(${mobileScale})`
-              : "translate(-50%, -50%)",
-            transformOrigin: "center center",
-            width: SCENE_W,
-            height: SCENE_H,
+            inset: 0,
+            transformOrigin: "0 0",
           }}
         >
-          <Walls
-            onToggleTheme={toggleTheme}
-            onWallPanelClick={(x, y) => setWallMenu({ x, y })}
-            hasOfficePrompt={!!officePrompt}
-            onOpenTasks={onOpenTasks}
-            onOpenCronjobs={onOpenCronjobs}
-            taskCount={tasks.filter(t => t.status !== "done" && t.status !== "backlog").length}
-            leftDoor={currentRoom > 0 ? { label: roomNames[currentRoom - 1] ?? `Room ${currentRoom}`, onClick: () => dispatch({ type: "set_current_room", room: currentRoom - 1 }), dragOver: leftDoorDragOver, reject: leftDoorReject } : null}
-            rightDoor={currentRoom < roomCount - 1 ? { label: roomNames[currentRoom + 1] ?? `Room ${currentRoom + 2}`, onClick: () => dispatch({ type: "set_current_room", room: currentRoom + 1 }), dragOver: rightDoorDragOver, reject: rightDoorReject } : null}
-          />
-          <Floor />
-          <RoomProps />
-          {currentRoom > 0 && (
-            <DoorDropZone
-              side="left"
-              onClick={() => dispatch({ type: "set_current_room", room: currentRoom - 1 })}
-              onDragOverChange={(over) => setLeftDoorDragOver(over)}
-              onDrop={(deskIndex) => {
-                const a = roomAgents.find((a) => a.desk === deskIndex);
-                if (!a) { setLeftDoorReject(true); setTimeout(() => setLeftDoorReject(false), 400); return false; }
-                const targetRoom = currentRoom - 1;
-                const targetRoomId = rooms[targetRoom]?.id;
-                if (!targetRoomId || agents.filter((x) => x.room === targetRoom).length >= 8) { setLeftDoorReject(true); setTimeout(() => setLeftDoorReject(false), 400); return false; }
-                send({ type: "move_agent", agentId: a.id, targetRoomId });
-                return true;
-              }}
+          {/* Centered scene container — static centering transform */}
+          <div
+            ref={viewport.setContent}
+            style={{
+              position: "absolute",
+              left: "50%",
+              top: embed ? (isMobile ? "55%" : "64%") : isMobile ? "45%" : "50%",
+              transform: embed
+                ? `translate(-50%, -50%) scale(${isMobile ? mobileScale * 0.85 : 0.9})`
+                : isMobile
+                ? `translate(-50%, -50%) scale(${mobileScale})`
+                : "translate(-50%, -50%)",
+              transformOrigin: "center center",
+              width: SCENE_W,
+              height: SCENE_H,
+            }}
+          >
+            <Walls
+              onToggleTheme={toggleTheme}
+              onWallPanelClick={(x, y) => setWallMenu({ x, y })}
+              hasOfficePrompt={!!officePrompt}
+              onOpenTasks={onOpenTasks}
+              onOpenCronjobs={onOpenCronjobs}
+              taskCount={tasks.filter(t => t.status !== "done" && t.status !== "backlog").length}
+              leftDoor={currentRoom > 0 ? { label: roomNames[currentRoom - 1] ?? `Room ${currentRoom}`, onClick: () => dispatch({ type: "set_current_room", room: currentRoom - 1 }), dragOver: leftDoorDragOver, reject: leftDoorReject } : null}
+              rightDoor={currentRoom < roomCount - 1 ? { label: roomNames[currentRoom + 1] ?? `Room ${currentRoom + 2}`, onClick: () => dispatch({ type: "set_current_room", room: currentRoom + 1 }), dragOver: rightDoorDragOver, reject: rightDoorReject } : null}
             />
-          )}
-          {currentRoom < roomCount - 1 && (
-            <DoorDropZone
-              side="right"
-              onClick={() => dispatch({ type: "set_current_room", room: currentRoom + 1 })}
-              onDragOverChange={(over) => setRightDoorDragOver(over)}
-              onDrop={(deskIndex) => {
-                const a = roomAgents.find((a) => a.desk === deskIndex);
-                if (!a) { setRightDoorReject(true); setTimeout(() => setRightDoorReject(false), 400); return false; }
-                const targetRoom = currentRoom + 1;
-                const targetRoomId = rooms[targetRoom]?.id;
-                if (!targetRoomId || agents.filter((x) => x.room === targetRoom).length >= 8) { setRightDoorReject(true); setTimeout(() => setRightDoorReject(false), 400); return false; }
-                send({ type: "move_agent", agentId: a.id, targetRoomId });
-                return true;
-              }}
-            />
-          )}
-          {Array.from({ length: 8 }, (_, i) => {
-            const agent = roomAgents.find((a) => a.desk === i);
-            if (agent) {
-              return (
-                <DeskUnit
-                  key={agent.id}
-                  agent={agent}
-                  onClick={() => dispatch({ type: "focus", agentId: agent.id })}
-                  onContextMenu={(e) => onContextMenu(e.clientX, e.clientY, agent)}
-                  needsAttention={needsAttention.has(agent.id)}
-                  onSwap={(a, b) => { const rid = rooms[currentRoom]?.id; if (rid) send({ type: "swap_desks", deskA: a, deskB: b, roomId: rid }); }}
-                  stateChangedAt={stateChangedAt.get(agent.id)}
-                />
-              );
-            }
-            return <EmptySlot key={`empty-${i}`} deskIndex={i} onClick={() => onSpawn(i)} onSwap={(a, b) => { const rid = rooms[currentRoom]?.id; if (rid) send({ type: "swap_desks", deskA: a, deskB: b, roomId: rid }); }} />;
-          })}
+            <Floor />
+            <RoomProps />
+            {currentRoom > 0 && (
+              <DoorDropZone
+                side="left"
+                onClick={viewport.wrapClick(() => dispatch({ type: "set_current_room", room: currentRoom - 1 }))}
+                onDragOverChange={(over) => setLeftDoorDragOver(over)}
+                onDrop={(deskIndex) => {
+                  const a = roomAgents.find((a) => a.desk === deskIndex);
+                  if (!a) { setLeftDoorReject(true); setTimeout(() => setLeftDoorReject(false), 400); return false; }
+                  const targetRoom = currentRoom - 1;
+                  const targetRoomId = rooms[targetRoom]?.id;
+                  if (!targetRoomId || agents.filter((x) => x.room === targetRoom).length >= 8) { setLeftDoorReject(true); setTimeout(() => setLeftDoorReject(false), 400); return false; }
+                  send({ type: "move_agent", agentId: a.id, targetRoomId });
+                  return true;
+                }}
+              />
+            )}
+            {currentRoom < roomCount - 1 && (
+              <DoorDropZone
+                side="right"
+                onClick={viewport.wrapClick(() => dispatch({ type: "set_current_room", room: currentRoom + 1 }))}
+                onDragOverChange={(over) => setRightDoorDragOver(over)}
+                onDrop={(deskIndex) => {
+                  const a = roomAgents.find((a) => a.desk === deskIndex);
+                  if (!a) { setRightDoorReject(true); setTimeout(() => setRightDoorReject(false), 400); return false; }
+                  const targetRoom = currentRoom + 1;
+                  const targetRoomId = rooms[targetRoom]?.id;
+                  if (!targetRoomId || agents.filter((x) => x.room === targetRoom).length >= 8) { setRightDoorReject(true); setTimeout(() => setRightDoorReject(false), 400); return false; }
+                  send({ type: "move_agent", agentId: a.id, targetRoomId });
+                  return true;
+                }}
+              />
+            )}
+            {Array.from({ length: 8 }, (_, i) => {
+              const agent = roomAgents.find((a) => a.desk === i);
+              if (agent) {
+                return (
+                  <DeskUnit
+                    key={agent.id}
+                    agent={agent}
+                    onClick={viewport.wrapClick(() => dispatch({ type: "focus", agentId: agent.id }))}
+                    onContextMenu={(e) => onContextMenu(e.clientX, e.clientY, agent)}
+                    needsAttention={needsAttention.has(agent.id)}
+                    onSwap={(a, b) => { const rid = rooms[currentRoom]?.id; if (rid) send({ type: "swap_desks", deskA: a, deskB: b, roomId: rid }); }}
+                    stateChangedAt={stateChangedAt.get(agent.id)}
+                  />
+                );
+              }
+              return <EmptySlot key={`empty-${i}`} deskIndex={i} onClick={viewport.wrapClick(() => onSpawn(i))} onSwap={(a, b) => { const rid = rooms[currentRoom]?.id; if (rid) send({ type: "swap_desks", deskA: a, deskB: b, roomId: rid }); }} />;
+            })}
+          </div>
         </div>
+
+        {/* Zoom controls */}
+        {!embed && <ZoomControls onZoomIn={viewport.zoomIn} onZoomOut={viewport.zoomOut} onReset={viewport.resetView} />}
 
         {/* Vignette */}
         {!embed && <div
@@ -304,8 +380,8 @@ export function OfficeView({ onSpawn, onContextMenu, onOpenUserSettings, onOpenD
         }}
       >
         {(isMobile
-          ? ["TAP → open", "LONG-PRESS → actions"]
-          : ["CLICK → open agent", "DRAG → swap desks or move to door", "RIGHT-CLICK → actions", "ESC → back"]
+          ? ["TAP → open", "LONG-PRESS → actions", "PINCH → zoom", "DRAG (zoomed) → pan"]
+          : ["CLICK → open agent", "DRAG → swap desks or move to door", "WHEEL / +- → zoom", "DRAG → pan", "RIGHT-CLICK → actions", "0 → reset view"]
         ).map((h, i) => (
           <span
             key={i}

--- a/ui/office/ZoomControls.tsx
+++ b/ui/office/ZoomControls.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+
+function ZoomButton({
+  onClick,
+  title,
+  "aria-label": ariaLabel,
+  children,
+  marginTop = 0,
+}: {
+  onClick: () => void;
+  title: string;
+  "aria-label": string;
+  children: React.ReactNode;
+  marginTop?: number;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const [pressed, setPressed] = useState(false);
+  const [focused, setFocused] = useState(false);
+
+  const background = pressed
+    ? "var(--bg-hover)"
+    : hovered
+    ? "var(--accent-hover)"
+    : "var(--btn-surface)";
+  const borderColor = focused || hovered ? "var(--border-light)" : "var(--border-medium)";
+  const color = focused || hovered ? "var(--text)" : "var(--text-dim)";
+
+  return (
+    <button
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: 32,
+        height: 32,
+        marginTop,
+        borderRadius: 8,
+        border: `1px solid ${borderColor}`,
+        background,
+        color,
+        fontSize: 16,
+        fontWeight: 600,
+        cursor: "pointer",
+        backdropFilter: "blur(8px)",
+        lineHeight: 1,
+        padding: 0,
+        fontFamily: "'JetBrains Mono', monospace",
+        boxShadow: focused ? "0 0 0 2px var(--accent-hover)" : hovered ? "0 8px 18px var(--shadow-heavy)" : "none",
+        transform: pressed ? "translateY(1px) scale(0.98)" : "translateY(0) scale(1)",
+        transition: "background 120ms ease, border-color 120ms ease, color 120ms ease, box-shadow 120ms ease, transform 80ms ease",
+        outline: "none",
+      }}
+      onClick={onClick}
+      title={title}
+      aria-label={ariaLabel}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => {
+        setHovered(false);
+        setPressed(false);
+      }}
+      onMouseDown={() => setPressed(true)}
+      onMouseUp={() => setPressed(false)}
+      onBlur={() => {
+        setFocused(false);
+        setPressed(false);
+      }}
+      onFocus={() => setFocused(true)}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function ZoomControls({ onZoomIn, onZoomOut, onReset }: { onZoomIn: () => void; onZoomOut: () => void; onReset: () => void }) {
+
+  return (
+    <div
+      data-no-pan
+      style={{
+        position: "absolute",
+        bottom: 12,
+        right: 12,
+        display: "flex",
+        flexDirection: "column",
+        gap: 4,
+        zIndex: 400,
+      }}
+    >
+      <ZoomButton onClick={onZoomIn} title="Zoom in" aria-label="Zoom in">+</ZoomButton>
+      <ZoomButton onClick={onZoomOut} title="Zoom out" aria-label="Zoom out">-</ZoomButton>
+      <ZoomButton onClick={onReset} title="Reset view (0)" aria-label="Reset view" marginTop={4}>
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
+          <circle cx="7" cy="7" r="5.5" />
+          <line x1="7" y1="4" x2="7" y2="10" />
+          <line x1="4" y1="7" x2="10" y2="7" />
+        </svg>
+      </ZoomButton>
+    </div>
+  );
+}

--- a/ui/office/useViewport.ts
+++ b/ui/office/useViewport.ts
@@ -1,0 +1,683 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+export interface ViewportState {
+  x: number;
+  y: number;
+  scale: number;
+}
+
+/** All numeric knobs for the viewport. Grouped so they're easy to find and tune. */
+const VIEWPORT = {
+  MIN_SCALE: 0.5,
+  MAX_SCALE: 2.5,
+  /** Epsilon above 1.0 used to decide "zoomed in". Avoids floating-point drift from wheel scrolls just above rest. */
+  ZOOM_EPSILON: 1.01,
+  /** Pixels of pointer movement before a mousedown becomes a pan. */
+  PAN_THRESHOLD: 5,
+  /** Scale factor applied per wheel-pixel delta. */
+  WHEEL_ZOOM_SPEED: 0.001,
+  /** Zoom multiplier for +/- button or keyboard shortcuts. */
+  ZOOM_STEP: 1.25,
+  /** Fraction of the container that must remain occupied by the scene at the edge. */
+  PAN_MARGIN: 0.25,
+  RESET_TRANSITION: "transform 0.25s ease-out",
+  RESET_CLEAR_MS: 300,
+} as const;
+
+const DEFAULT_STATE: ViewportState = { x: 0, y: 0, scale: 1 };
+
+// Pan should start from any non-interactive surface in the scene. Every clickable
+// target in the scene — including native HTML5 drag sources like DeskUnit — opts
+// out via `data-no-pan`, so we don't need a separate [draggable] rule here.
+const PAN_BLOCKER_SELECTOR = "[data-no-pan], button, a, input, textarea, select";
+// Touch-only blocker: excludes [data-no-pan]. The big 180×160 desk/slot
+// hit-rects blanket the visible floor — treating them as pan blockers would make
+// one-finger pan fail almost everywhere when zoomed in. Tap-vs-drag stays safe
+// because: (a) DeskUnit preventDefaults touchstart and dispatches its own
+// clicks from touchend, so browser-synthesized clicks on a desk aren't the
+// trigger path; (b) EmptySlot and other data-no-pan click targets rely on
+// synthesized clicks, and wrapClick + didPan gate those on idle gestures.
+const TOUCH_PAN_BLOCKER_SELECTOR = "button, a, input, textarea, select";
+
+function clampScale(scale: number) {
+  return Math.max(VIEWPORT.MIN_SCALE, Math.min(VIEWPORT.MAX_SCALE, scale));
+}
+
+/**
+ * Explicit gesture state machine. Transitions:
+ *   idle     → panning   (mouse/pen pointerdown OR single-finger touchstart
+ *                         when zoomed in, both on a pannable target)
+ *   panning  → idle      (pointerup | pointercancel | touchend | touchcancel)
+ *   panning  → pinching  (second finger arrives; releases any captured pointer
+ *                         so the remaining single touch after the pinch ends
+ *                         doesn't reactivate a stale anchor)
+ *   idle     → pinching  (two fingers land simultaneously)
+ *   pinching → idle      (fingers drop below two | touchcancel)
+ *
+ * `source` distinguishes pan drivers: "pointer" pans are authoritatively owned
+ * by a specific pointerId and use pointer capture; "touch" pans are driven by
+ * TouchEvents (iOS Safari's pointer-event path is unreliable for sustained
+ * single-finger drag — pointercancel fires even with touch-action: none, and
+ * setPointerCapture on a touch pointer can drop pointermove deliveries).
+ *
+ * `panning.committed` distinguishes a pending tap (within the click threshold)
+ * from an actual drag — uncommitted panning never mutates the viewport.
+ */
+type Gesture =
+  | { kind: "idle" }
+  | {
+      kind: "panning";
+      source: "pointer" | "touch";
+      pointerId: number; // unused when source === "touch"
+      committed: boolean;
+      startX: number;
+      startY: number;
+      initialSX: number;
+      initialSY: number;
+    }
+  | {
+      kind: "pinching";
+      startDist: number;
+      initial: ViewportState;
+      initialMidX: number;
+      initialMidY: number;
+    };
+
+/**
+ * Hook that manages zoom/pan for the office scene. Attaches wheel, pointer,
+ * and touch listeners to the container, and mutates the scene transform
+ * directly to avoid React re-renders during gestures.
+ *
+ * Per-room view state is keyed by room ID (not index) so mid-list deletions
+ * don't mis-associate saved zoom/pan with a neighbouring room.
+ *
+ * `layoutKey` should change whenever the centered scene's static transform
+ * changes (e.g. embed/isMobile/mobileScale flip) so the pan-clamp boundaries
+ * re-measure. ResizeObserver only fires on container size changes and won't
+ * notice transform-only updates.
+ *
+ * When `enabled` is false, gesture listeners are not attached (wheel, pointer,
+ * touch, pinch all become no-ops) — used to disable zoom in embed mode where
+ * the UI chrome and keyboard shortcuts are already hidden.
+ *
+ * Returns callback refs (`setContainer`, `setScene`, `setContent`) instead of
+ * RefObjects — attach them via `ref={...}` on the corresponding elements.
+ */
+export function useViewport(currentRoomId: string, roomIds: readonly string[], layoutKey: string, enabled: boolean) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const sceneRef = useRef<HTMLDivElement | null>(null);
+  /** The scene-content element inside the zoom/pan layer — measured for pan-clamp bounds. */
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  // State mirror of containerRef so the listener-attachment effect re-runs when
+  // the container node is (re)attached. Scene/content are only read from
+  // handlers, so refs alone suffice for those.
+  const [container, setContainerState] = useState<HTMLDivElement | null>(null);
+
+  const setContainer = useCallback((node: HTMLDivElement | null) => {
+    containerRef.current = node;
+    setContainerState(node);
+  }, []);
+  const setScene = useCallback((node: HTMLDivElement | null) => {
+    sceneRef.current = node;
+  }, []);
+  const setContent = useCallback((node: HTMLDivElement | null) => {
+    contentRef.current = node;
+  }, []);
+
+  const roomStates = useRef<Map<string, ViewportState>>(new Map());
+  const state = useRef<ViewportState>({ ...DEFAULT_STATE });
+  const gesture = useRef<Gesture>({ kind: "idle" });
+  /** Scene content bounds in viewport-layer-local coords (pre-zoom). Null until measured. */
+  const sceneBounds = useRef<{ left: number; right: number; top: number; bottom: number } | null>(null);
+  /** True if the most recent pointer gesture became a pan — used to suppress click-to-focus */
+  const didPan = useRef(false);
+  const currentRoomIdRef = useRef(currentRoomId);
+  currentRoomIdRef.current = currentRoomId;
+  const roomIdsRef = useRef(roomIds);
+  roomIdsRef.current = roomIds;
+  const resetClearTimer = useRef<number | null>(null);
+  const restoreUserSelect = useRef<string | null>(null);
+
+  function clearResetTransition() {
+    const scene = sceneRef.current;
+    if (scene && scene.style.transition) {
+      scene.style.transition = "";
+    }
+    if (resetClearTimer.current !== null) {
+      clearTimeout(resetClearTimer.current);
+      resetClearTimer.current = null;
+    }
+  }
+
+  /** Abandon any in-flight gesture: release pointer capture, restore cursor and
+   *  body userSelect, clear didPan, and return the state machine to idle. Called
+   *  when gestures must be abandoned mid-flight — on room change (anchors reference
+   *  the outgoing room) or when listeners detach (enabled toggle / unmount). */
+  function abortAllGestures() {
+    const g = gesture.current;
+    if (g.kind === "panning" && g.source === "pointer") {
+      const c = containerRef.current;
+      if (c) {
+        if (c.hasPointerCapture(g.pointerId)) {
+          c.releasePointerCapture(g.pointerId);
+        }
+        c.style.cursor = "";
+      }
+    }
+    if (restoreUserSelect.current !== null) {
+      document.body.style.userSelect = restoreUserSelect.current;
+      restoreUserSelect.current = null;
+    }
+    didPan.current = false;
+    gesture.current = { kind: "idle" };
+  }
+
+  function applyTransform(animate = false) {
+    const scene = sceneRef.current;
+    if (!scene) {
+      return;
+    }
+    const { x, y, scale } = state.current;
+    // Only touch scene.style.transition if one is currently set — otherwise
+    // every pointermove would write a no-op. Reading the live style is the
+    // source of truth; the reset timer is its companion (set together, cleared
+    // together).
+    clearResetTransition();
+    if (animate) {
+      scene.style.transition = VIEWPORT.RESET_TRANSITION;
+      resetClearTimer.current = window.setTimeout(() => {
+        scene.style.transition = "";
+        resetClearTimer.current = null;
+      }, VIEWPORT.RESET_CLEAR_MS);
+    }
+    scene.style.transform = `translate(${x}px, ${y}px) scale(${scale})`;
+  }
+
+  /**
+   * Measure the scene content's bounding box in viewport-layer-local coords
+   * (pre-zoom), by inverting the currently-rendered transform. Caller must
+   * ensure state.current matches the last rendered transform — i.e. call
+   * after applyTransform, not between a state mutation and its apply.
+   */
+  function measureSceneBounds() {
+    const container = containerRef.current;
+    const content = contentRef.current;
+    if (!container || !content) {
+      sceneBounds.current = null;
+      return;
+    }
+    const crect = container.getBoundingClientRect();
+    const rect = content.getBoundingClientRect();
+    if (crect.width === 0 || crect.height === 0 || rect.width === 0 || rect.height === 0) {
+      // Hidden containers/content report zero rects; keep bounds unset so clampPan
+      // becomes a no-op until a visible re-measure arrives.
+      sceneBounds.current = null;
+      return;
+    }
+    const { x, y, scale } = state.current;
+    sceneBounds.current = {
+      left: (rect.left - crect.left - x) / scale,
+      right: (rect.right - crect.left - x) / scale,
+      top: (rect.top - crect.top - y) / scale,
+      bottom: (rect.bottom - crect.top - y) / scale,
+    };
+  }
+
+  function clampPan() {
+    const container = containerRef.current;
+    const b = sceneBounds.current;
+    if (!container || !b) {
+      return;
+    }
+    const { scale } = state.current;
+    const cw = container.clientWidth;
+    const ch = container.clientHeight;
+    // Keep PAN_MARGIN of the container spanned by the scene at each edge.
+    const maxX = (1 - VIEWPORT.PAN_MARGIN) * cw - scale * b.left;
+    const minX = VIEWPORT.PAN_MARGIN * cw - scale * b.right;
+    const maxY = (1 - VIEWPORT.PAN_MARGIN) * ch - scale * b.top;
+    const minY = VIEWPORT.PAN_MARGIN * ch - scale * b.bottom;
+    state.current.x = Math.max(minX, Math.min(maxX, state.current.x));
+    state.current.y = Math.max(minY, Math.min(maxY, state.current.y));
+  }
+
+  function zoomAt(cx: number, cy: number, newScale: number) {
+    const s = state.current;
+    const clamped = clampScale(newScale);
+    const ratio = clamped / s.scale;
+    s.x = cx - ratio * (cx - s.x);
+    s.y = cy - ratio * (cy - s.y);
+    s.scale = clamped;
+    clampPan();
+    applyTransform();
+  }
+
+  function save() {
+    const id = currentRoomIdRef.current;
+    if (!id) {
+      return;
+    }
+    roomStates.current.set(id, { ...state.current });
+  }
+
+  // The callbacks below are `useCallback(..., [])` because every value they
+  // reach — state, gesture, refs, and the in-body helpers (applyTransform,
+  // zoomAt, save, measureSceneBounds, clampPan) — is stored in a ref or
+  // reads through one. No render-scoped variable is closed over. If you add
+  // a line here that captures component state or props, switch to refs or
+  // add the dep; otherwise the callback will silently use stale values.
+  // sceneBounds are layer-local (measureSceneBounds inverts the live transform),
+  // so they're invariant under state changes — no need to re-measure after
+  // resetting. At DEFAULT_STATE, clampPan is a no-op by construction.
+  const resetView = useCallback((animate = true) => {
+    state.current = { ...DEFAULT_STATE };
+    save();
+    applyTransform(animate);
+  }, []);
+
+  const zoomIn = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const rect = container.getBoundingClientRect();
+    zoomAt(rect.width / 2, rect.height / 2, state.current.scale * VIEWPORT.ZOOM_STEP);
+    save();
+  }, []);
+
+  const zoomOut = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const rect = container.getBoundingClientRect();
+    zoomAt(rect.width / 2, rect.height / 2, state.current.scale / VIEWPORT.ZOOM_STEP);
+    save();
+  }, []);
+
+  /** True when the user has zoomed in past the rest scale — used to route one-finger drags
+   *  to pan instead of swipe on touch (iOS-gallery pattern). */
+  const isZoomedIn = useCallback(() => state.current.scale > VIEWPORT.ZOOM_EPSILON, []);
+
+  /** Wrap a click handler so it's suppressed when the click was actually a drag-pan. */
+  const wrapClick = useCallback(<A extends unknown[]>(cb: (...args: A) => void) => {
+    return (...args: A) => {
+      if (!didPan.current) {
+        cb(...args);
+      }
+    };
+  }, []);
+
+  // Restore per-room state on room change.
+  useEffect(() => {
+    // Any in-flight gesture references the outgoing room's anchor — abandon it.
+    abortAllGestures();
+
+    const saved = roomStates.current.get(currentRoomId);
+    state.current = saved ? { ...saved } : { ...DEFAULT_STATE };
+    // Write the new room's transform to the DOM BEFORE measuring. measureSceneBounds
+    // inverts the scene's live transform using state.current — if the DOM still
+    // reflects the outgoing room's transform at this point, the computed bounds
+    // are shifted and scaled by (old - new), leaving clampPan using wrong edges
+    // for every subsequent pan/zoom in the new room.
+    applyTransform();
+    measureSceneBounds();
+    clampPan();
+    // Re-apply only if clampPan mutated state; a no-op apply writes the same
+    // transform string so it's cheap either way.
+    applyTransform();
+  }, [currentRoomId]);
+
+  // Prune saved state for rooms that no longer exist. Split from the
+  // restore effect so deleting a non-current room doesn't abort an in-flight
+  // gesture or re-apply the current room's transform.
+  // Room IDs are persistent identities — once assigned, they don't mutate in
+  // place. Pruning is only ever needed on deletion, which drops the length,
+  // so length alone is a sufficient change detector.
+  useEffect(() => {
+    const valid = new Set(roomIdsRef.current);
+    for (const key of Array.from(roomStates.current.keys())) {
+      if (!valid.has(key)) {
+        roomStates.current.delete(key);
+      }
+    }
+  }, [roomIds.length]);
+
+  // Re-measure scene bounds when the centered scene's static transform
+  // changes (embed/isMobile/mobileScale). ResizeObserver only catches
+  // container size changes, not transform-only updates to inner content.
+  useEffect(() => {
+    measureSceneBounds();
+    clampPan();
+    applyTransform();
+  }, [layoutKey]);
+
+  // This effect's deps are `[container, enabled]`. The DOM handlers registered
+  // below close over in-body helpers (applyTransform, zoomAt, clampPan, save,
+  // measureSceneBounds). Those helpers are recreated on every render, but the
+  // handlers captured here reference the version from the render when the
+  // effect last ran — which is fine ONLY because every helper reaches state
+  // through refs and closes over no render-scoped values. If you add a line
+  // to any helper that captures props or useState values, either add the dep
+  // here (and accept listener churn) or route the new value through a ref.
+  useEffect(() => {
+    if (!container || !enabled) {
+      return;
+    }
+    const resetGesture = (shouldSave = false) => {
+      if (shouldSave && gesture.current.kind !== "idle") {
+        save();
+      }
+      gesture.current = { kind: "idle" };
+    };
+    const startPan = (source: "pointer" | "touch", clientX: number, clientY: number, pointerId = -1) => {
+      gesture.current = {
+        kind: "panning",
+        source,
+        pointerId,
+        committed: false,
+        startX: clientX,
+        startY: clientY,
+        initialSX: state.current.x,
+        initialSY: state.current.y,
+      };
+    };
+
+    function isPanBlocker(target: HTMLElement) {
+      return !!target.closest(PAN_BLOCKER_SELECTOR);
+    }
+
+    function isTouchPanBlocker(target: HTMLElement) {
+      return !!target.closest(TOUCH_PAN_BLOCKER_SELECTOR);
+    }
+
+    function releasePan(pointerId: number) {
+      if (container!.hasPointerCapture(pointerId)) {
+        container!.releasePointerCapture(pointerId);
+      }
+      container!.style.cursor = "";
+      if (restoreUserSelect.current !== null) {
+        document.body.style.userSelect = restoreUserSelect.current;
+        restoreUserSelect.current = null;
+      }
+    }
+
+    function enterPinch(t1: Touch, t2: Touch) {
+      if (gesture.current.kind === "panning" && gesture.current.source === "pointer") {
+        // Release the primary pointer's capture so lifting back to a single
+        // touch after the pinch doesn't reactivate the old pan anchor.
+        // Touch-driven pans don't use pointer capture — nothing to release.
+        releasePan(gesture.current.pointerId);
+      }
+      const rect = container!.getBoundingClientRect();
+      gesture.current = {
+        kind: "pinching",
+        startDist: Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY),
+        initial: { ...state.current },
+        initialMidX: (t1.clientX + t2.clientX) / 2 - rect.left,
+        initialMidY: (t1.clientY + t2.clientY) / 2 - rect.top,
+      };
+    }
+
+    function handleWheel(e: WheelEvent) {
+      e.preventDefault();
+      const rect = container!.getBoundingClientRect();
+      const cx = e.clientX - rect.left;
+      const cy = e.clientY - rect.top;
+      // Normalize deltaY to pixels so Firefox line-mode and page-mode wheels zoom at the same rate as pixel-mode.
+      const lineHeight = 16;
+      const unit = e.deltaMode === 1 ? lineHeight : e.deltaMode === 2 ? rect.height : 1;
+      const delta = -e.deltaY * unit * VIEWPORT.WHEEL_ZOOM_SPEED;
+      zoomAt(cx, cy, state.current.scale * (1 + delta));
+      save();
+    }
+
+    function handlePointerDown(e: PointerEvent) {
+      // Touch-driven pan is handled in handleTouchStart (TouchEvents are more
+      // reliable than pointer events on iOS for sustained single-finger pan).
+      // Reset didPan only for non-touch pointers here — touch resets happen in
+      // handleTouchStart on a fresh single-finger tap.
+      if (e.pointerType === "touch") {
+        return;
+      }
+      didPan.current = false;
+      if (e.button !== 0) {
+        return;
+      }
+      if (gesture.current.kind === "pinching") {
+        return;
+      }
+      if (isPanBlocker(e.target as HTMLElement)) {
+        return;
+      }
+      e.preventDefault();
+      startPan("pointer", e.clientX, e.clientY, e.pointerId);
+      container!.setPointerCapture(e.pointerId);
+      if (restoreUserSelect.current === null) {
+        restoreUserSelect.current = document.body.style.userSelect;
+        document.body.style.userSelect = "none";
+      }
+    }
+
+    function handlePointerMove(e: PointerEvent) {
+      const g = gesture.current;
+      if (g.kind !== "panning" || g.source !== "pointer" || g.pointerId !== e.pointerId) {
+        return;
+      }
+      const dx = e.clientX - g.startX;
+      const dy = e.clientY - g.startY;
+      e.preventDefault();
+      if (!g.committed) {
+        if (Math.abs(dx) < VIEWPORT.PAN_THRESHOLD && Math.abs(dy) < VIEWPORT.PAN_THRESHOLD) {
+          return;
+        }
+        g.committed = true;
+        didPan.current = true;
+        container!.style.cursor = "grabbing";
+      }
+      state.current.x = g.initialSX + dx;
+      state.current.y = g.initialSY + dy;
+      clampPan();
+      applyTransform();
+    }
+
+    function handlePointerUp(e: PointerEvent) {
+      const g = gesture.current;
+      if (g.kind !== "panning" || g.source !== "pointer" || g.pointerId !== e.pointerId) {
+        return;
+      }
+      releasePan(e.pointerId);
+      if (g.committed) {
+        save();
+      }
+      // Safe to clear here: pointer capture retargets the synthesized click to
+      // the container, not to any wrapClick'd descendant, so no stale-didPan
+      // window exists for mouse pans. Reset anyway to make the invariant
+      // (didPan is true only between commit and end-of-gesture) explicit.
+      didPan.current = false;
+      resetGesture();
+    }
+
+    function handlePointerCancel(e: PointerEvent) {
+      const g = gesture.current;
+      if (g.kind !== "panning" || g.source !== "pointer" || g.pointerId !== e.pointerId) {
+        return;
+      }
+      handlePointerUp(e);
+    }
+
+    function handleNativeDragStart(e: DragEvent) {
+      if (gesture.current.kind === "panning" && gesture.current.source === "pointer") {
+        e.preventDefault();
+      }
+    }
+
+    function handleSelectStart(e: Event) {
+      if (gesture.current.kind === "panning" && gesture.current.source === "pointer") {
+        e.preventDefault();
+      }
+    }
+
+    function handleTouchStart(e: TouchEvent) {
+      if (e.touches.length >= 2) {
+        enterPinch(e.touches[0], e.touches[1]);
+        return;
+      }
+      if (e.touches.length !== 1 || gesture.current.kind !== "idle") {
+        return;
+      }
+      // DeskUnit's touch handler preventDefaults, which suppresses the
+      // synthesized pointerdown — reset didPan on a fresh tap so a post-pan
+      // tap on a desk isn't swallowed by the pan's lingering flag.
+      didPan.current = false;
+      // One-finger touches at rest scale belong to the swipe-to-change-room
+      // hook (iOS-gallery pattern). Once zoomed in, the user needs one-finger
+      // pan to look around, so we take the gesture back.
+      if (state.current.scale <= VIEWPORT.ZOOM_EPSILON) {
+        return;
+      }
+      const t = e.touches[0];
+      const tgt = t.target as HTMLElement | null;
+      if (tgt && isTouchPanBlocker(tgt)) {
+        return;
+      }
+      startPan("touch", t.clientX, t.clientY);
+    }
+
+    function handleTouchMove(e: TouchEvent) {
+      const g = gesture.current;
+      if (g.kind === "pinching" && e.touches.length >= 2) {
+        e.preventDefault();
+        const t1 = e.touches[0];
+        const t2 = e.touches[1];
+        const dist = Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY);
+        const rect = container!.getBoundingClientRect();
+        const newMidX = (t1.clientX + t2.clientX) / 2 - rect.left;
+        const newMidY = (t1.clientY + t2.clientY) / 2 - rect.top;
+
+        const newScale = g.initial.scale * (dist / g.startDist);
+        const clamped = clampScale(newScale);
+        const scaleRatio = clamped / g.initial.scale;
+
+        // Zoom anchored at the current midpoint, pinning the scene point that
+        // sat under the midpoint when the pinch began:
+        //   new.x = newMid - r * (initialMid - initial.x)
+        state.current.x = newMidX - scaleRatio * (g.initialMidX - g.initial.x);
+        state.current.y = newMidY - scaleRatio * (g.initialMidY - g.initial.y);
+        state.current.scale = clamped;
+        clampPan();
+        applyTransform();
+        return;
+      }
+      if (g.kind === "panning" && g.source === "touch" && e.touches.length === 1) {
+        const t = e.touches[0];
+        const dx = t.clientX - g.startX;
+        const dy = t.clientY - g.startY;
+        if (!g.committed) {
+          if (Math.abs(dx) < VIEWPORT.PAN_THRESHOLD && Math.abs(dy) < VIEWPORT.PAN_THRESHOLD) {
+            return;
+          }
+          g.committed = true;
+          didPan.current = true;
+        }
+        // Only preventDefault once the pan has committed. On iOS, a
+        // preventDefault on any touchmove suppresses the browser-synthesized
+        // click — we want that suppression for a real drag, but not for a
+        // tap whose finger trembled a few pixels inside PAN_THRESHOLD (e.g.
+        // tapping an EmptySlot to spawn while zoomed in).
+        if (e.cancelable) {
+          e.preventDefault();
+        }
+        state.current.x = g.initialSX + dx;
+        state.current.y = g.initialSY + dy;
+        clampPan();
+        applyTransform();
+      }
+    }
+
+    function handleTouchEnd(e: TouchEvent) {
+      const g = gesture.current;
+      if (g.kind === "pinching") {
+        if (e.touches.length < 2) {
+          resetGesture(true);
+        } else {
+          // A finger lifted from a 3+ finger pinch, leaving two on-screen.
+          // Re-anchor so startDist/initialMid match the remaining pair —
+          // otherwise the next touchmove snaps scale/position using stale
+          // anchors from the prior finger configuration.
+          enterPinch(e.touches[0], e.touches[1]);
+        }
+        return;
+      }
+      if (g.kind === "panning" && g.source === "touch" && e.touches.length === 0) {
+        // didPan is intentionally NOT cleared here — it must survive past the
+        // iOS-synthesized click window so wrapClick can suppress the tap that
+        // follows a drag-pan. The next fresh single-finger tap clears it in
+        // handleTouchStart. Do not "unify" this with handlePointerUp's reset.
+        resetGesture(g.committed);
+      }
+    }
+
+    function handleTouchCancel() {
+      const g = gesture.current;
+      // iOS palm rejection / system gesture can cancel mid-pan. Reset any
+      // touch-driven gesture state unconditionally so the next fresh touch
+      // starts clean.
+      if (g.kind === "panning" && g.source === "touch") {
+        resetGesture(g.committed);
+      } else if (g.kind === "pinching") {
+        resetGesture(true);
+      }
+    }
+
+    const ro = new ResizeObserver(() => {
+      // The centered scene's layer-local position depends on container size.
+      measureSceneBounds();
+      clampPan();
+      applyTransform();
+    });
+    ro.observe(container);
+
+    container.addEventListener("wheel", handleWheel, { passive: false });
+    container.addEventListener("pointerdown", handlePointerDown);
+    container.addEventListener("pointermove", handlePointerMove);
+    container.addEventListener("pointerup", handlePointerUp);
+    container.addEventListener("pointercancel", handlePointerCancel);
+    container.addEventListener("dragstart", handleNativeDragStart);
+    container.addEventListener("selectstart", handleSelectStart);
+    container.addEventListener("touchstart", handleTouchStart, { passive: true });
+    container.addEventListener("touchmove", handleTouchMove, { passive: false });
+    container.addEventListener("touchend", handleTouchEnd, { passive: true });
+    container.addEventListener("touchcancel", handleTouchCancel, { passive: true });
+
+    return () => {
+      ro.disconnect();
+      clearResetTransition();
+      container.removeEventListener("wheel", handleWheel);
+      container.removeEventListener("pointerdown", handlePointerDown);
+      container.removeEventListener("pointermove", handlePointerMove);
+      container.removeEventListener("pointerup", handlePointerUp);
+      container.removeEventListener("pointercancel", handlePointerCancel);
+      container.removeEventListener("dragstart", handleNativeDragStart);
+      container.removeEventListener("selectstart", handleSelectStart);
+      container.removeEventListener("touchstart", handleTouchStart);
+      container.removeEventListener("touchmove", handleTouchMove);
+      container.removeEventListener("touchend", handleTouchEnd);
+      container.removeEventListener("touchcancel", handleTouchCancel);
+      // Must come AFTER removeEventListener calls: abortAllGestures releases
+      // pointer capture, which can synthesize a pointercancel — we don't want
+      // that dispatching into the handler we're about to remove.
+      abortAllGestures();
+    };
+  }, [container, enabled]);
+
+  return {
+    setContainer,
+    setScene,
+    setContent,
+    resetView,
+    zoomIn,
+    zoomOut,
+    isZoomedIn,
+    wrapClick,
+  };
+}


### PR DESCRIPTION
New `useViewport` hook encapsulates viewport state and input handling (pinch/drag on touch, wheel/buttons/keyboard on desktop). `ZoomControls` provides on-screen buttons. Coordinates with `useSwipeLeftRight` via a `shouldStart` predicate so room-swiping and viewport panning share the same container without conflict.