### PR TITLE
Group react and react-dom dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Prevents recurrence of the peer-dep mismatch fixed in 2fea0f2, where react was bumped independently of react-dom. With this group, dependabot will open a single PR covering both.